### PR TITLE
Added javafx to gradle builde file.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,13 @@
+plugins {
+	id 'org.openjfx.javafxplugin' version '0.0.8'
+	id 'java'
+}
+
+javafx {
+	version = "11"
+	modules = [ 'javafx.controls', 'javafx.fxml']
+}
+
 apply plugin: 'java'
 apply plugin: 'idea'
 


### PR DESCRIPTION
Helps fix any issues in the event the person building doesn't have javafx "in the right place."

All credit goes to @aTom3333 for actually writing these changes.

(Tried adding him co-author feature, though he hasn't shown up on the commit, which I suspect means he needs to accept it. Haven't used it before so I have no clue.)